### PR TITLE
添加头文件utilities.h到axi4_socket.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
@@ -13,13 +13,13 @@ add_executable(TrafficExample
     ${CMAKE_SOURCE_DIR}/src/libarmaxi4.cpp
 )
 
-find_library(SYSTEMC_LIB systemc PATHS /00_ycl/02_install/systemc/systemc-2.3.3/lib-linux64)
+find_library(SYSTEMC_LIB systemc PATHS /00_ycl/04_install/systemc-2.3.4/lib-linux64)
 target_link_libraries(TrafficExample PUBLIC ${SYSTEMC_LIB})  
 
 target_include_directories(TrafficExample PUBLIC
                           "${CMAKE_SOURCE_DIR}/examples/amba_tlm/"
                           "${CMAKE_SOURCE_DIR}/include/"
-                          "/00_ycl/02_install/systemc/systemc-2.3.3/include"
+                          "/00_ycl/04_install/systemc-2.3.4/include"
                           )
                           
 target_compile_options(TrafficExample PRIVATE "-g")                          

--- a/examples/amba_tlm/Monitor.cpp
+++ b/examples/amba_tlm/Monitor.cpp
@@ -10,20 +10,20 @@ using namespace tlm;
 using namespace sc_core;
 using namespace ARM::AXI4;
 
-tlm_sync_enum Monitor::nb_transport_fw(Payload& payload, Phase& phase)
+tlm_sync_enum Monitor::nb_transport_fw(int id, Payload& payload, Phase& phase)
 {
     Phase prev_phase = phase;
-    tlm_sync_enum reply = master.nb_transport_fw(payload, phase);
+    tlm_sync_enum reply = master.nb_transport_fw(id, payload, phase);
 
     print_payload(payload, prev_phase, reply, phase);
 
     return reply;
 }
 
-tlm_sync_enum Monitor::nb_transport_bw(Payload& payload, Phase& phase)
+tlm_sync_enum Monitor::nb_transport_bw(int id, Payload& payload, Phase& phase)
 {
     Phase prev_phase = phase;
-    tlm_sync_enum reply = slave.nb_transport_bw(payload, phase);
+    tlm_sync_enum reply = slave.nb_transport_bw(id, payload, phase);
 
     print_payload(payload, prev_phase, reply, phase);
 

--- a/examples/amba_tlm/Monitor.h
+++ b/examples/amba_tlm/Monitor.h
@@ -16,9 +16,9 @@ protected:
     /* Map of burst counts for observed Payloads. */
     std::map<ARM::AXI4::Payload*, unsigned> payload_burst_index;
 
-    tlm::tlm_sync_enum nb_transport_fw(ARM::AXI4::Payload& payload,
+    tlm::tlm_sync_enum nb_transport_fw(int id, ARM::AXI4::Payload& payload,
         ARM::AXI4::Phase& phase);
-    tlm::tlm_sync_enum nb_transport_bw(ARM::AXI4::Payload& payload,
+    tlm::tlm_sync_enum nb_transport_bw(int id, ARM::AXI4::Payload& payload,
         ARM::AXI4::Phase& phase);
 
     void print_payload(ARM::AXI4::Payload& payload,
@@ -29,8 +29,8 @@ public:
     Monitor(sc_core::sc_module_name name, unsigned port_width = 128);
     ~Monitor();
 
-    ARM::AXI4::SimpleSlaveSocket<Monitor> slave;
-    ARM::AXI4::SimpleMasterSocket<Monitor> master;
+    ARM::AXI4::SlaveMultiSockets<Monitor> slave;
+    ARM::AXI4::MasterMultiSockets<Monitor> master;
 };
 
 #endif // ARM_MONITOR_H

--- a/include/ARM/TLM/arm_axi4.h
+++ b/include/ARM/TLM/arm_axi4.h
@@ -39,5 +39,6 @@
 #include "arm_axi4_payload.h"
 #include "arm_axi4_phase.h"
 #include "arm_axi4_socket.h"
+#include "arm_axi4_multi_socket.h"
 
 #endif // ARM_AXI4_H

--- a/include/ARM/TLM/arm_axi4_multi_socket.h
+++ b/include/ARM/TLM/arm_axi4_multi_socket.h
@@ -14,7 +14,7 @@ namespace AXI4
  * Payload and Phase grouped for use with socket templates in a similar
  * way to tlm::tlm_base_protocol_types.
  */
-class ProtocolType
+class MyProtocolType
 {
 public:
     typedef Payload tlm_payload_type;
@@ -22,7 +22,7 @@ public:
 };
 
 /** ARM::TLM::MasterMultiSockets specialised for AXI4 payloads/phases. */
-template <typename Module, typename Types = ProtocolType>
+template <typename Module, typename Types = MyProtocolType>
 class MasterMultiSockets : public ARM::TLM::MasterMultiSockets <Module, Types>
 {
 private:
@@ -37,7 +37,7 @@ public:
 };
 
 /** ARM::TLM::SlaveMultiSockets specialised for AXI4 payloads/phases. */
-template <typename Module, typename Types = ProtocolType>
+template <typename Module, typename Types = MyProtocolType>
 class SlaveMultiSockets : public ARM::TLM::SlaveMultiSockets <Module, Types>
 {
 private:

--- a/include/ARM/TLM/arm_axi4_multi_socket.h
+++ b/include/ARM/TLM/arm_axi4_multi_socket.h
@@ -1,0 +1,59 @@
+#ifndef ARM_AXI4_MULTI_SOCKET_H
+#define ARM_AXI4_MULTI_SOCKET_H
+
+#include "arm_axi4_payload.h"
+#include "arm_axi4_phase.h"
+#include "arm_tlm_multi_socket.h"
+
+namespace ARM
+{
+namespace AXI4
+{
+
+/**
+ * Payload and Phase grouped for use with socket templates in a similar
+ * way to tlm::tlm_base_protocol_types.
+ */
+class ProtocolType
+{
+public:
+    typedef Payload tlm_payload_type;
+    typedef Phase tlm_phase_type;
+};
+
+/** ARM::TLM::MasterMultiSockets specialised for AXI4 payloads/phases. */
+template <typename Module, typename Types = ProtocolType>
+class MasterMultiSockets : public ARM::TLM::MasterMultiSockets <Module, Types>
+{
+private:
+    typedef typename ARM::TLM::MasterMultiSockets<Module, Types> BaseType;
+
+public:
+    MasterMultiSockets(const char* name_, Module& t,
+        typename BaseType::NBFunc bw,
+        TLM::Protocol protocol_, unsigned width_) :
+        TLM::MasterMultiSockets <Module, Types>(name_, t, bw, protocol_, width_)
+    {}
+};
+
+/** ARM::TLM::SlaveMultiSockets specialised for AXI4 payloads/phases. */
+template <typename Module, typename Types = ProtocolType>
+class SlaveMultiSockets : public ARM::TLM::SlaveMultiSockets <Module, Types>
+{
+private:
+    typedef typename ARM::TLM::SlaveMultiSockets<Module, Types> BaseType;
+
+public:
+    SlaveMultiSockets(const char* name_, Module& t,
+        typename BaseType::NBFunc fw,
+        TLM::Protocol protocol_, unsigned width_,
+        typename BaseType::DebugFunc dbg = NULL) :
+        TLM::SlaveMultiSockets <Module, Types>(name_, t, fw,
+            protocol_, width_, dbg)
+    {}
+};
+
+}
+}
+
+#endif // ARM_AXI4_SOCKET_H

--- a/include/ARM/TLM/arm_axi4_socket.h
+++ b/include/ARM/TLM/arm_axi4_socket.h
@@ -39,9 +39,7 @@
 #include "arm_axi4_payload.h"
 #include "arm_axi4_phase.h"
 #include "arm_tlm_socket.h"
-#include "utilities.h"
-#include "tlm_utils/simple_initiator_socket.h"
-#include "tlm_utils/simple_target_socket.h"
+
 namespace ARM
 {
 namespace AXI4
@@ -57,20 +55,7 @@ public:
     typedef Payload tlm_payload_type;
     typedef Phase tlm_phase_type;
 };
-/*
-template <typename Module, typename Types = ProtocolType>
-class MultiMasterSockets : tlm_utils::multi_passthrough_target_socket<Module, Types>
-{
-private:
-    typedef typename ARM::TLM::MultiMasterSockets<Module, Types> BaseType;
-public:
-    MultiMasterSockets(const char* name_, Module& t,
-        typename BaseType::NBFunc bw,
-        TLM::Portocol protocol_, unsigned width_) :
-        TLM::MultiMasterSocekt <Module, Types>(name_, t, bw, protocol_, width_) 
-    {}
-};
-*/
+
 /** ARM::TLM::SimpleMasterSocket specialised for AXI4 payloads/phases. */
 template <typename Module, typename Types = ProtocolType>
 class SimpleMasterSocket : public ARM::TLM::SimpleMasterSocket <Module, Types>

--- a/include/ARM/TLM/arm_axi4_socket.h
+++ b/include/ARM/TLM/arm_axi4_socket.h
@@ -39,7 +39,9 @@
 #include "arm_axi4_payload.h"
 #include "arm_axi4_phase.h"
 #include "arm_tlm_socket.h"
-
+#include "utilities.h"
+#include "tlm_utils/simple_initiator_socket.h"
+#include "tlm_utils/simple_target_socket.h"
 namespace ARM
 {
 namespace AXI4
@@ -55,7 +57,20 @@ public:
     typedef Payload tlm_payload_type;
     typedef Phase tlm_phase_type;
 };
-
+/*
+template <typename Module, typename Types = ProtocolType>
+class MultiMasterSockets : tlm_utils::multi_passthrough_target_socket<Module, Types>
+{
+private:
+    typedef typename ARM::TLM::MultiMasterSockets<Module, Types> BaseType;
+public:
+    MultiMasterSockets(const char* name_, Module& t,
+        typename BaseType::NBFunc bw,
+        TLM::Portocol protocol_, unsigned width_) :
+        TLM::MultiMasterSocekt <Module, Types>(name_, t, bw, protocol_, width_) 
+    {}
+};
+*/
 /** ARM::TLM::SimpleMasterSocket specialised for AXI4 payloads/phases. */
 template <typename Module, typename Types = ProtocolType>
 class SimpleMasterSocket : public ARM::TLM::SimpleMasterSocket <Module, Types>

--- a/include/ARM/TLM/arm_tlm_multi_socket.h
+++ b/include/ARM/TLM/arm_tlm_multi_socket.h
@@ -40,7 +40,7 @@ public:
 
 /** Base master socket implementing protocol/width checking. */
 template <typename Types>
-class BaseMasterMultiSockets : public tlm::multi_passthrough_target_socket<Types>
+class BaseMasterMultiSockets : public tlm::multi_passthrough_initiator_socket<Types>
 {
 public:
     /* Protocol to test against other sockets when binding. */
@@ -52,7 +52,7 @@ public:
 public:
     BaseMasterMultiSockets(const char* name_,
         Protocol protocol_, unsigned port_width_) :
-        tlm::multi_passthrough_target_socket<Types>(name_),
+        tlm::multi_passthrough_initiator_socket<Types>(name_),
         protocol(protocol_),
         port_width(port_width_)
     {}
@@ -74,6 +74,57 @@ public:
     /** Non blocking transport function pointer. */
     typedef tlm::tlm_sync_enum (Module::* NBFunc)(int, PayloadType&, PhaseType&);
 
+    /** Debug transport function pointer. */
+    typedef unsigned (Module::* DebugFunc)(PayloadType&);
+
+protected:
+    /** Proxy object implementing the fw transport interface. */
+    class Proxy : public tlm::tlm_fw_transport_if<Types>
+    {
+    public:
+        /** Owner of the proxy. */
+        const SlaveMultiSockets<Module, Types>& owner;
+
+        /** Object and functions to which to defer interface calls. */
+        Module& t;
+        NBFunc fw;
+        DebugFunc dbg;
+
+        Proxy(const SlaveMultiSockets<Module, Types>& owner_,
+            Module& t_, NBFunc fw_, DebugFunc dbg_) :
+            owner(owner_), t(t_), fw(fw_), dbg(dbg_)
+        {}
+
+        tlm::tlm_sync_enum nb_transport_fw(int id, PayloadType& trans,
+            PhaseType& phase, sc_core::sc_time& delay)
+        {
+            return (t.*fw)(trans, phase);
+        }
+
+        void b_transport(int id, PayloadType& trans, sc_core::sc_time& delay)
+        {
+            std::ostringstream message;
+            message << owner.name() << ": b_transport not implemented";
+            SC_REPORT_ERROR("/ARM/TLM/SimpleSlaveSocket",
+                message.str().c_str());
+        }
+
+        unsigned transport_dbg(PayloadType& trans)
+        {
+            if (dbg)
+                return (t.*dbg)(trans);
+            else
+                return 0;
+        }
+
+        bool get_direct_mem_ptr(PayloadType&, tlm::tlm_dmi&)
+        {
+            return false;
+        }
+    };
+
+    Proxy proxy;
+
 public:
     SlaveMultiSockets(const char* name_, Module& t, NBFunc fw,
         Protocol protocol_, unsigned port_width_, DebugFunc dbg = NULL) :
@@ -84,11 +135,12 @@ public:
     }
 
     /** Convenience function for bw without time. */
-    tlm::tlm_sync_enum nb_transport_bw(inti id, PayloadType& trans, PhaseType& phase)
+    tlm::tlm_sync_enum nb_transport_bw(int id, PayloadType& trans, PhaseType& phase)
     {
         sc_core::sc_time delay = sc_core::SC_ZERO_TIME;
-        return (*this)->nb_transport_bw(id, trans, phase, delay);
+        return (*this)->nb_transport_bw(trans, phase, delay);
     }
+
 };
 
 /**
@@ -97,7 +149,7 @@ public:
  * same way at tlm_utils::simple_initiator_socket.
  */
 template <typename Module, typename Types>
-class SimpleMasterSocket : public BaseMasterSocket<Types>
+class MasterMultiSockets : public BaseMasterMultiSockets<Types>
 {
 protected:
     typedef typename Types::tlm_payload_type PayloadType;
@@ -113,13 +165,13 @@ protected:
     {
     public:
         /** Owner of the proxy. */
-        const SimpleMasterSocket<Module, Types>& owner;
+        const MasterMultiSockets<Module, Types>& owner;
 
         /** Object and function(s) to which to defer interface calls. */
         Module& t;
         NBFunc bw;
 
-        Proxy(const SimpleMasterSocket<Module, Types>& owner_,
+        Proxy(const MasterMultiSockets<Module, Types>& owner_,
             Module& t_, NBFunc bw_) :
             owner(owner_), t(t_), bw(bw_)
         {}
@@ -142,12 +194,12 @@ protected:
     Proxy proxy;
 
 public:
-    SimpleMasterSocket(const char* name_, Module& t, NBFunc bw,
+    MasterMultiSockets(const char* name_, Module& t, NBFunc bw,
         Protocol protocol_, unsigned port_width_) :
-        BaseMasterSocket<Types>(name_, protocol_, port_width_),
+        BaseMasterMultiSockets<Types>(name_, protocol_, port_width_),
         proxy(*this, t, bw)
     {
-        tlm::tlm_initiator_socket<0, Types>::bind(proxy);
+        tlm::multi_passthrough_initiator_socket<Types>::bind(proxy);
     }
 
     /** Convenience function for fw without time. */

--- a/include/ARM/TLM/arm_tlm_multi_socket.h
+++ b/include/ARM/TLM/arm_tlm_multi_socket.h
@@ -20,7 +20,7 @@ class BaseMasterMultiSockets;
 
 /* Base slave socket implementing protocol/width checking. */
 template <typename Types>
-class BaseSlaveMultiSockets : public tlm::multi_passthrough_target_socket<Types>
+class BaseSlaveMultiSockets : public tlm_utils::multi_passthrough_target_socket<Types>
 {
 public:
     /* Protocol to test against other sockets when binding. */
@@ -32,7 +32,7 @@ public:
 public:
     BaseSlaveMultiSockets(const char* name_,
         Protocol protocol_, unsigned port_width_) :
-        tlm::multi_passthrough_target_socket<Types>(name_),
+        tlm_utils::multi_passthrough_target_socket<Types>(name_),
         protocol(protocol_),
         port_width(port_width_)
     {}
@@ -40,7 +40,7 @@ public:
 
 /** Base master socket implementing protocol/width checking. */
 template <typename Types>
-class BaseMasterMultiSockets : public tlm::multi_passthrough_initiator_socket<Types>
+class BaseMasterMultiSockets : public tlm_utils::multi_passthrough_initiator_socket<Types>
 {
 public:
     /* Protocol to test against other sockets when binding. */
@@ -52,7 +52,7 @@ public:
 public:
     BaseMasterMultiSockets(const char* name_,
         Protocol protocol_, unsigned port_width_) :
-        tlm::multi_passthrough_initiator_socket<Types>(name_),
+        tlm_utils::multi_passthrough_initiator_socket<Types>(name_),
         protocol(protocol_),
         port_width(port_width_)
     {}
@@ -199,7 +199,7 @@ public:
         BaseMasterMultiSockets<Types>(name_, protocol_, port_width_),
         proxy(*this, t, bw)
     {
-        tlm::multi_passthrough_initiator_socket<Types>::bind(proxy);
+        tlm_utils::multi_passthrough_initiator_socket<Types>::bind(proxy);
     }
 
     /** Convenience function for fw without time. */

--- a/include/ARM/TLM/arm_tlm_multi_socket.h
+++ b/include/ARM/TLM/arm_tlm_multi_socket.h
@@ -1,0 +1,164 @@
+#ifndef ARM_TLM_MULTI_SOCKET_H
+#define ARM_TLM_MULTI_SOCKET_H
+
+#include <tlm.h>
+#include <sstream>
+
+#include "arm_tlm_protocol.h"
+#include "utilities.h"
+#include "tlm_utils/multi_passthrough_initiator_socket.h"
+#include "tlm_utils/multi_passthrough_target_socket.h"
+
+namespace ARM
+{
+namespace TLM
+{
+
+/* we must decleare BaseMasterSocket here, or we will get bug */
+template <typename Types>
+class BaseMasterMultiSockets;
+
+/* Base slave socket implementing protocol/width checking. */
+template <typename Types>
+class BaseSlaveMultiSockets : public tlm::multi_passthrough_target_socket<Types>
+{
+public:
+    /* Protocol to test against other sockets when binding. */
+    const Protocol protocol;
+
+    /** Port data width to test against other sockets when binding. */
+    const unsigned port_width;
+
+public:
+    BaseSlaveMultiSockets(const char* name_,
+        Protocol protocol_, unsigned port_width_) :
+        tlm::multi_passthrough_target_socket<Types>(name_),
+        protocol(protocol_),
+        port_width(port_width_)
+    {}
+};
+
+/** Base master socket implementing protocol/width checking. */
+template <typename Types>
+class BaseMasterMultiSockets : public tlm::multi_passthrough_target_socket<Types>
+{
+public:
+    /* Protocol to test against other sockets when binding. */
+    const Protocol protocol;
+
+    /** Port data width to test against other sockets when binding. */
+    const unsigned port_width;
+
+public:
+    BaseMasterMultiSockets(const char* name_,
+        Protocol protocol_, unsigned port_width_) :
+        tlm::multi_passthrough_target_socket<Types>(name_),
+        protocol(protocol_),
+        port_width(port_width_)
+    {}
+};
+
+/**
+ * Simple slave socket allowing a Module class to implement communication
+ * functions as member functions and register them with the socket in the
+ * same way at tlm_utils::simple_target_socket.
+ */
+template <typename Module, typename Types>
+class SlaveMultiSockets : public BaseSlaveMultiSockets<Types>
+{
+protected:
+    typedef typename Types::tlm_payload_type PayloadType;
+    typedef typename Types::tlm_phase_type PhaseType;
+
+public:
+    /** Non blocking transport function pointer. */
+    typedef tlm::tlm_sync_enum (Module::* NBFunc)(int, PayloadType&, PhaseType&);
+
+public:
+    SlaveMultiSockets(const char* name_, Module& t, NBFunc fw,
+        Protocol protocol_, unsigned port_width_, DebugFunc dbg = NULL) :
+        BaseSlaveMultiSockets<Types>(name_, protocol_, port_width_),
+        proxy(*this, t, fw, dbg)
+    {
+        this->bind(proxy);
+    }
+
+    /** Convenience function for bw without time. */
+    tlm::tlm_sync_enum nb_transport_bw(inti id, PayloadType& trans, PhaseType& phase)
+    {
+        sc_core::sc_time delay = sc_core::SC_ZERO_TIME;
+        return (*this)->nb_transport_bw(id, trans, phase, delay);
+    }
+};
+
+/**
+ * Simple slave socket allowing a Module class to implement communication
+ * functions as member functions and register them with the socket in the
+ * same way at tlm_utils::simple_initiator_socket.
+ */
+template <typename Module, typename Types>
+class SimpleMasterSocket : public BaseMasterSocket<Types>
+{
+protected:
+    typedef typename Types::tlm_payload_type PayloadType;
+    typedef typename Types::tlm_phase_type PhaseType;
+
+public:
+    /** Non blocking transport function pointer. */
+    typedef tlm::tlm_sync_enum (Module::* NBFunc)(int, PayloadType&, PhaseType&);
+
+protected:
+    /** Proxy object implementing the bw transport interface. */
+    class Proxy : public tlm::tlm_bw_transport_if<Types>
+    {
+    public:
+        /** Owner of the proxy. */
+        const SimpleMasterSocket<Module, Types>& owner;
+
+        /** Object and function(s) to which to defer interface calls. */
+        Module& t;
+        NBFunc bw;
+
+        Proxy(const SimpleMasterSocket<Module, Types>& owner_,
+            Module& t_, NBFunc bw_) :
+            owner(owner_), t(t_), bw(bw_)
+        {}
+
+        tlm::tlm_sync_enum nb_transport_bw(int id, PayloadType& trans,
+            PhaseType& phase, sc_core::sc_time& delay)
+        {
+            return (t.*bw)(trans, phase);
+        }
+
+        void invalidate_direct_mem_ptr(sc_dt::uint64, sc_dt::uint64)
+        {
+            std::ostringstream message;
+            message << owner.name() << ": DMI not implemented";
+            SC_REPORT_ERROR("/ARM/TLM/SimpleMasterSocket",
+                message.str().c_str());
+        }
+    };
+
+    Proxy proxy;
+
+public:
+    SimpleMasterSocket(const char* name_, Module& t, NBFunc bw,
+        Protocol protocol_, unsigned port_width_) :
+        BaseMasterSocket<Types>(name_, protocol_, port_width_),
+        proxy(*this, t, bw)
+    {
+        tlm::tlm_initiator_socket<0, Types>::bind(proxy);
+    }
+
+    /** Convenience function for fw without time. */
+    tlm::tlm_sync_enum nb_transport_fw(int id, PayloadType& trans, PhaseType& phase)
+    {
+        sc_core::sc_time delay = sc_core::SC_ZERO_TIME;
+        return (*this)->nb_transport_fw(id, trans, phase, delay);
+    }
+};
+
+}
+}
+
+#endif // ARM_TLM_SOCKET_H

--- a/include/ARM/TLM/arm_tlm_socket.h
+++ b/include/ARM/TLM/arm_tlm_socket.h
@@ -46,6 +46,7 @@ namespace ARM
 namespace TLM
 {
 
+/* we must decleare BaseMasterSocket here, or we will get bug */
 template <typename Types>
 class BaseMasterSocket;
 

--- a/include/ARM/TLM/utilities.h
+++ b/include/ARM/TLM/utilities.h
@@ -1,0 +1,75 @@
+#ifndef UTILITIES_H
+#define UTILITIES_H
+
+#include "systemc"
+using namespace sc_core;
+using namespace sc_dt;
+using namespace std;
+
+#include "tlm.h"
+#include <fstream>
+
+static ofstream fout("output.txt");
+
+// **************************************************************************************
+// User-defined memory manager, which maintains a pool of transactions
+// **************************************************************************************
+
+class mm: public tlm::tlm_mm_interface
+{
+  typedef tlm::tlm_generic_payload gp_t;
+
+public:
+  mm() : free_list(0), empties(0) {}
+
+  gp_t* allocate() {
+    gp_t* ptr;
+    if (free_list)
+    {
+      ptr = free_list->trans;
+      empties = free_list;
+      free_list = free_list->next;
+    }
+    else
+    {
+      ptr = new gp_t(this);
+    }
+    return ptr;
+  }
+  void  free(gp_t* trans) {
+    if (!empties)
+    {
+      empties = new access;
+      empties->next = free_list;
+      empties->prev = 0;
+      if (free_list)
+        free_list->prev = empties;
+    }
+    free_list = empties;
+    free_list->trans = trans;
+    empties = free_list->prev;
+  }
+
+private:
+  struct access
+  {
+    gp_t* trans;
+    access* next;
+    access* prev;
+  };
+
+  access* free_list;
+  access* empties;
+
+};
+
+/*
+// Generate a random delay (with power-law distribution) to aid testing and stress the protocol
+int rand_ps()
+{
+  int n = rand() % 100;
+  n = n * n * n;
+  return n / 100;
+}
+*/
+#endif


### PR DESCRIPTION
- 存在问题：

头文件utilities.h中实现了类函数（非内联函数）会导致编译时多处引用，导致链接utilities.h函数会出现多重定义错误。

- 解决方案：

所以需要修改到类内定义，而不是类内声明，类外定义，或者新增cpp文件。